### PR TITLE
[Feature] Added new stage - "Stopped ❌"

### DIFF
--- a/server/db/migrations/000013_add_stopped_stage.sql
+++ b/server/db/migrations/000013_add_stopped_stage.sql
@@ -1,0 +1,8 @@
+CREATE stage:stopped CONTENT {
+  name: 'Stopped ❌',
+  description: 'Companies that you prevented from progressing (due to various factors, including their actions or your decisions,...)',
+  is_final_stage: true,
+  is_bad_stage: true,
+  color: 'red',
+  position: 65
+};


### PR DESCRIPTION
So when in the middle of the progress, your journey item could be in the "Stopped" stage, due to any factor, eg:

- Company stopped the hiring
- You found out their range is not match with your expectation
- ...

Thus, you should be able to move that Journey Item to "Stopped" stage. This PR added that.

"Stopped" stage considered as a "bad stage" which will collect your bad feedback (if any), so you will have a good visibility if you applied with that company later on